### PR TITLE
Update xcvrd to use new STATE_DB FAST_REBOOT entry

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -928,7 +928,7 @@ def is_fast_reboot_enabled():
 
     if "system" in keys:
         output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'get', "FAST_REBOOT|system"], universal_newlines=True)
-        if "1" in output:
+        if "enable" in output:
             fastboot_enabled = True
 
     return fastboot_enabled


### PR DESCRIPTION
Update xcvrd to check if fast-reboot is enabled according to the new value for FAST_REBOOT entry in STATE_DB.

#### Description
Update xcvrd to check the updated form of fast-reboot entry in state-db as it was changed.

#### Motivation and Context
Introducing fast-reboot finalizer on top of warmboot-finalizer, fast-reboot entry in STATE_DB is now changed from "1"/None to "enable"/"disable".

#### How Has This Been Tested?
Existing tests, and fast-reboot.

#### Additional Information (Optional)
