### PR TITLE
Update xcvrd to use new STATE_DB FAST_REBOOT entry

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -927,8 +927,8 @@ def is_fast_reboot_enabled():
     keys = fastboot_tbl.getKeys()
 
     if "system" in keys:
-        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'get', "FAST_RESTART_ENABLE_TABLE|system"], universal_newlines=True)
-        if "enable" in output:
+        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'hget', "FAST_RESTART_ENABLE_TABLE|system", 'enable'], universal_newlines=True)
+        if "true" in output:
             fastboot_enabled = True
 
     return fastboot_enabled

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -923,11 +923,11 @@ def init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event=threadi
 def is_fast_reboot_enabled():
     fastboot_enabled = False
     state_db_host =  daemon_base.db_connect("STATE_DB")
-    fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_REBOOT')
+    fastboot_tbl = swsscommon.Table(state_db_host, 'FAST_RESTART_ENABLE_TABLE')
     keys = fastboot_tbl.getKeys()
 
     if "system" in keys:
-        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'get', "FAST_REBOOT|system"], universal_newlines=True)
+        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'get', "FAST_RESTART_ENABLE_TABLE|system"], universal_newlines=True)
         if "enable" in output:
             fastboot_enabled = True
 

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -927,8 +927,8 @@ def is_fast_reboot_enabled():
     keys = fastboot_tbl.getKeys()
 
     if "system" in keys:
-        output = subprocess.check_output('sonic-db-cli STATE_DB get "FAST_REBOOT|system"', shell=True, universal_newlines=True)
-        if "1" in output:
+        output = subprocess.check_output(['sonic-db-cli', 'STATE_DB', 'get', "FAST_REBOOT|system"], universal_newlines=True)
+        if "enable" in output:
             fastboot_enabled = True
 
     return fastboot_enabled


### PR DESCRIPTION
Update xcvrd to check if fast-reboot is enabled according to the new value for FAST_REBOOT entry in STATE_DB.



This PR is similar to 335, it is dedicated to 202205.

Description
Update xcvrd to check the updated form of fast-reboot entry in state-db as it was changed.

Motivation and Context
Introducing fast-reboot finalizer on top of warmboot-finalizer, fast-reboot entry in STATE_DB is now changed from "1"/None to "enable"/"disable".