### PR TITLE
Add 'sys_display' to chassis table in STATE_DB

### DIFF
--- a/sonic-chassisd/scripts/chassis_db_init
+++ b/sonic-chassisd/scripts/chassis_db_init
@@ -32,6 +32,7 @@ CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
 CHASSIS_INFO_SERIAL_FIELD = 'serial'
 CHASSIS_INFO_MODEL_FIELD = 'model'
 CHASSIS_INFO_REV_FIELD = 'revision'
+CHASSIS_INFO_SYS_DISPLAY_FIELD = 'sys_display'
 
 CHASSIS_LOAD_ERROR = 1
 
@@ -64,18 +65,19 @@ def try_get(callback, *args, **kwargs):
 
 #
 # Functions
-# 
+#
 
 def provision_db(platform_chassis, log):
     # Init state db connection
     state_db = daemon_base.db_connect("STATE_DB")
     chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
 
-    # Populate DB with chassis hardware info 
+    # Populate DB with chassis hardware info
     fvs = swsscommon.FieldValuePairs([
                                         (CHASSIS_INFO_SERIAL_FIELD, try_get(platform_chassis.get_serial)),
                                         (CHASSIS_INFO_MODEL_FIELD, try_get(platform_chassis.get_model)),
-                                        (CHASSIS_INFO_REV_FIELD, try_get(platform_chassis.get_revision))
+                                        (CHASSIS_INFO_REV_FIELD, try_get(platform_chassis.get_revision)),
+                                        (CHASSIS_INFO_SYS_DISPLAY_FIELD, try_get(platform_chassis.get_sys_display))
                                     ])
     chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
     log.log_info("STATE_DB provisioned with chassis info.")

--- a/sonic-chassisd/tests/mock_platform.py
+++ b/sonic-chassisd/tests/mock_platform.py
@@ -32,7 +32,7 @@ class MockModule(MockDevice):
         self.midplane_access = False
         self.asic_list = asic_list
         self.module_serial = module_serial
- 
+
     def get_name(self):
         return self.module_name
 
@@ -88,6 +88,7 @@ class MockChassis:
         self.module_list = []
         self.midplane_supervisor_access = False
         self._is_smartswitch = False
+        self._display_name = 'N/A'
 
     def get_num_modules(self):
         return len(self.module_list)
@@ -113,6 +114,9 @@ class MockChassis:
 
     def get_model(self):
         return "Model A"
+
+    def get_sys_display(self):
+        return self._display_name
 
     def get_revision(self):
         return "Rev C"
@@ -162,7 +166,7 @@ class MockSmartSwitchChassis:
 
     def is_smartswitch(self):
         return self._is_smartswitch
- 
+
     def get_dataplane_state(self):
         raise NotImplementedError
 

--- a/sonic-chassisd/tests/test_chassis_db_init.py
+++ b/sonic-chassisd/tests/test_chassis_db_init.py
@@ -29,6 +29,7 @@ def test_provision_db():
     serial = "Serial No"
     model = "Model A"
     revision = "Rev C"
+    display_name = NOT_AVAILABLE
 
     chassis_table = provision_db(chassis, log)
 
@@ -38,3 +39,4 @@ def test_provision_db():
     assert serial == fvs[CHASSIS_INFO_SERIAL_FIELD]
     assert model == fvs[CHASSIS_INFO_MODEL_FIELD]
     assert revision == fvs[CHASSIS_INFO_REV_FIELD]
+    assert display_name == fvs[CHASSIS_INFO_REV_FIELD]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Add 'sys_display' KV to chassis table in STATE_DB when initializing, value is retrieved from chassis.py - reads from VPD file.

#### Motivation and Context
This is required to enable enhancement of 'show platform summary' cli - adding also display name to it.

#### How Has This Been Tested?
Manually tested

#### Additional Information (Optional)
